### PR TITLE
Generated code uses eval() which doesn't work on CloudFlare Workers

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
     ignored: /node_modules|dist|\.js/g,
   },
 
-  devtool: 'cheap-module-eval-source-map',
+  devtool: 'none',
 
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],


### PR DESCRIPTION
I experimented with all of Webpack's devtool options, and the eval's were the only ones that _seemed_ produce correct line numbers in the log. However, this was actually just a fluke. The line numbers for my test case _just coincidentally lined up_. Doubly a fluke since the fiddle shouldn't be supporting `eval()` to begin with. Given that, I'm just removing sourcemaps from the preview altogether.

__Original__

> Although your [example](https://cloudflareworkers.com/#be6ec935c5692b703f4ce4615b47abc0:https://foo.bar.com/weather/austin) works on the cloudflareworkers.com site, it doesn't work in real CloudFlare workers because they don't permit eval() for security reasons according to the ECMAScript Builtins section of the [Reference](https://developers.cloudflare.com/workers/reference/) docs.
> 
> Is there some way to stop eval being generated?